### PR TITLE
Update poetry download site and version in Dockerfiles, add carla, networkx, and setuptools as dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7
 
 WORKDIR /usr/src/app
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - \
+RUN curl -sSL https://install.python-poetry.org | python - --version 1.5.1 \
     && export PATH="/root/.local/bin:$PATH"
 ENV PATH "/root/.local/bin:$PATH"
 

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -2,7 +2,7 @@ FROM python:3.7
 
 WORKDIR /usr/src/app
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - \
+RUN curl -sSL https://install.python-poetry.org | python - --version 1.5.1 \
     && export PATH="/root/.local/bin:$PATH"
 ENV PATH "/root/.local/bin:$PATH"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ decorator = "^5.0.9"
 pymoo = "0.5.0"
 carla = "^0.9.13"
 networkx = "2.4"
+setuptools = "59.6.0"
 importlib_metadata = { version = "^3.7", python = "~3.7" }
 
 pyproj = {version = "^3.0.0", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ pygame = "^2.0.1"
 attrs = "^19.3.0"
 decorator = "^5.0.9"
 pymoo = "0.5.0"
+carla = "^0.9.13"
+networkx = "2.4"
 importlib_metadata = { version = "^3.7", python = "~3.7" }
 
 pyproj = {version = "^3.0.0", optional = true}


### PR DESCRIPTION
1. The old download site of poetry in the Dockerfiles is now 404. Apparently they changed to a new one.
2. The latest poetry doesn't work with Python 3.7 anymore, and the latest version compatible seems to be 1.5.1
3. carla and networkx was missing in pyproject.toml
4. I had a new trouble running things starting at some point: "No module named 'pkg_resources'". This seems to do with Python setuptools. Among many solutions, I found one that worked, which is to explicitly declare a dependency on setuptools (https://github.com/python-poetry/poetry/issues/6328#issuecomment-1279813438)